### PR TITLE
Working with cli container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM quali/torque-cli:2.5.8
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yaml
+++ b/action.yaml
@@ -18,7 +18,7 @@ inputs:
     
 runs:
   using: "docker"
-  image: "docker://qtorque/torque-cli:1.7"
+  image: "docker://quali/torque-cli:2.5.8"
   args:
     - env
     - end

--- a/action.yaml
+++ b/action.yaml
@@ -18,17 +18,16 @@ inputs:
     
 runs:
   using: "docker"
-  image: "docker://quali/torque-cli:2.5.8"
+  image: "Dockerfile"
   args:
-    - env
-    - end
     - ${{ inputs.environment_id }}
+    - ${{ inputs.space }}
 
   env:
     TORQUE_TOKEN: ${{ inputs.torque_token }}
     TORQUE_SPACE: ${{ inputs.space }}
     TORQUE_HOSTNAME: ${{ inputs.torque_hostname }}
-    TORQUE_USERAGENT: Torque-Plugin-Github-Env-Environment-Action/v1
+    TORQUE_USERAGENT: Torque-Plugin-Github-Start-Environment-Action/v1
 
 branding:
   icon: 'stop-circle'  

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh -l
+
+ENV_ID="$1"
+SPACE="$2"
+
+echo "Ending environment with id '${ENV_ID}' in space '${SPACE}'"
+params="\"${ENV_ID}\" --space \"${SPACE}\""
+
+command="/Quali.Torque.Cli/torque-cli env end ${params} --token $TORQUE_TOKEN"
+echo "The following command will be executed: ${command}"
+
+echo "Ending environment..."
+response=$(eval $command 2>&1)
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+    echo "Error: Failed to end environment"
+    echo "$response"
+    exit $exit_code
+fi
+
+echo "Environment ended successfully."
+
+echo "Writing data to outputs"
+echo "environment_id=${ENV_ID}" >> $GITHUB_OUTPUT
+


### PR DESCRIPTION
This pull request updates the GitHub Action to use a custom Docker image and entrypoint script for ending environments, replacing the previous method that relied on a public image. The changes improve flexibility and control over the CLI invocation and output handling.

**Docker image and entrypoint update:**

* Added a new `Dockerfile` that uses `quali/torque-cli:2.5.8` as the base image and copies a custom `entrypoint.sh` script, setting it as the entrypoint.
* Replaced the previous public image reference in `action.yaml` with the local `Dockerfile`, ensuring the action uses the new custom image and entrypoint.

**Entrypoint script and CLI invocation:**

* Introduced `entrypoint.sh` to handle the environment ending process, including parameter parsing, CLI invocation, error handling, and output writing to GitHub Actions outputs.

**Action configuration and metadata:**

* Updated the arguments in `action.yaml` to match the new entrypoint script, including switching from `environment_id` to `space` and removing unused arguments.
* Changed the `TORQUE_USERAGENT` environment variable to reflect the new action name for improved tracking and identification.